### PR TITLE
Fix strict template bug (#44)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ speed-measure-plugin*.json
 *.launch
 .settings/
 *.sublime-workspace
+.angular/
 
 # IDE - VSCode
 .vscode/*

--- a/README.md
+++ b/README.md
@@ -20,6 +20,11 @@ module.ts
 component.html
 `<mat-sidenav mode="rail" opened="true">`
 
+If `"strictTemplates": true` is activated in _tsconfig.json_, overwriting mode is not possible. In this case you can use the following selector:
+
+component.html
+`<mat-sidenav rail-mode opened="true">`
+
 This extension adds on an existing `mode` the Material documentation remains the same.
 
 

--- a/projects/angular-material-rail-drawer-example/src/app/app.component.html
+++ b/projects/angular-material-rail-drawer-example/src/app/app.component.html
@@ -5,7 +5,7 @@
   <span>Mini Variant</span>
 </mat-toolbar>
 <mat-sidenav-container>
-  <mat-sidenav #appDrawer mode="rail" opened="false">
+  <mat-sidenav #appDrawer rail-mode opened="false">
     <mat-nav-list class="dashboard">
         <a mat-list-item>
           <mat-icon mat-list-icon >account_circle</mat-icon>

--- a/projects/angular-material-rail-drawer/src/lib/drawer-rail.directive.ts
+++ b/projects/angular-material-rail-drawer/src/lib/drawer-rail.directive.ts
@@ -33,7 +33,7 @@ import { Directionality } from '@angular/cdk/bidi';
 
 @Directive({
   // tslint:disable-next-line: directive-selector
-  selector: 'mat-sidenav[mode="rail"], mat-drawer[mode="rail"]',
+  selector: 'mat-sidenav[mode="rail"], mat-drawer[mode="rail"], mat-sidenav[rail-mode], mat-drawer[rail-mode]',
   // tslint:disable-next-line: no-host-metadata-property
   host: {
     '[class.mat-drawer-side]': 'true',

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,7 +24,8 @@
     }
   },
   "angularCompilerOptions": {
-    "fullTemplateTypeCheck": true,
-    "strictInjectionParameters": true
+    "strictInjectionParameters": true,
+    "strictInputAccessModifiers": true,
+    "strictTemplates": true
   }
 }


### PR DESCRIPTION
Newer Angular projects have `"strictTemplates": true` as default. And many editors (e.g. VS Code) recommend activating this mode.

If this mode is activated, the compiler actually checks the contents of the HTML files. Since the rail mode is not part of the `MatDrawerMode` enum, an error occurs.

As a workaround, as long as no extension of the enum is possible, a second selector is introduced that can be used alternatively if the strict template mode is active.

This should fix issue #44