### PR TITLE
Sidenav not visible when loaded as closed

### DIFF
--- a/projects/angular-material-rail-drawer/src/lib/drawer-rail.directive.ts
+++ b/projects/angular-material-rail-drawer/src/lib/drawer-rail.directive.ts
@@ -100,6 +100,7 @@ export class MatDrawerRailDirective
 
     this.drawer._closedStream.pipe(takeUntil(this.onDestory)).subscribe(() => {
       this.renderer2.setStyle(this.el.nativeElement, 'visibility', 'visible');
+      this.renderer2.setStyle(this.el.nativeElement, 'display', 'block');
     });
 
     this.drawer.openedStart.pipe(takeUntil(this.onDestory)).subscribe(() => {
@@ -115,6 +116,7 @@ export class MatDrawerRailDirective
       this.correctContentMargin(this.expandedWidth);
     } else {
       this.renderer2.setStyle(this.el.nativeElement, 'visibility', 'visible');
+      this.renderer2.setStyle(this.el.nativeElement, 'display', 'block');
       this.closeMenu();
     }
   }


### PR DESCRIPTION
In a recent Angular Materials update there is not only the visibility set when the Sidenav is displayed as closed, but it also gets a "display:none" set and that's why the Nav is not visible when first loading it as closed with this plugin.
See: https://github.com/angular/components/pull/24376#issue-1126959901