### PR TITLE
Add module back to public api (fixes #49)

### DIFF
--- a/projects/angular-material-rail-drawer/src/public-api.ts
+++ b/projects/angular-material-rail-drawer/src/public-api.ts
@@ -4,3 +4,4 @@
 export * from './lib/default.config';
 export * from './lib/animations.settings';
 export * from './lib/drawer-rail.directive';
+export * from './lib/drawer-rail.module';


### PR DESCRIPTION
Add the drawer module back to public_api.ts. Fixes #49 